### PR TITLE
Repo Structure Spec based proposal

### DIFF
--- a/repo_structure/CODE_OF_CONDUCT.md
+++ b/repo_structure/CODE_OF_CONDUCT.md
@@ -1,0 +1,166 @@
+# Hyperledger Code of Conduct
+
+Hyperledger is a collaborative project at The Linux Foundation. It is an open-source and open
+community project where participants choose to work together, and in that process experience
+differences in language, location, nationality, and experience. In such a diverse environment,
+misunderstandings and disagreements happen, which in most cases can be resolved informally. In rare
+cases, however, behavior can intimidate, harass, or otherwise disrupt one or more people in the
+community, which Hyperledger will not tolerate.
+
+A **Code of Conduct** is useful to define accepted and acceptable behaviors and to promote high
+standards of professional practice. It also provides a benchmark for self evaluation and acts as a
+vehicle for better identity of the organization.
+
+This code (**CoC**) applies to any member of the Hyperledger community – developers, participants in
+meetings, teleconferences, mailing lists, conferences or functions, etc. Note that this code
+complements rather than replaces legal rights and obligations pertaining to any particular
+situation.
+
+## Statement of Intent
+
+Hyperledger is committed to maintain a **positive** [work environment](#work-environment). This
+commitment calls for a workplace where [participants](#participant) at all levels behave according
+to the rules of the following code. A foundational concept of this code is that we all share
+responsibility for our work environment.
+
+## Code
+
+1. Treat each other with [respect](#respect), professionalism, fairness, and sensitivity to our many
+   differences and strengths, including in situations of high pressure and urgency.
+
+2. Never [harass](#harassment) or [bully](#workplace-bullying) anyone verbally, physically or
+   [sexually](#sexual-harassment).
+
+3. Never [discriminate](#discrimination) on the basis of personal characteristics or group
+   membership.
+
+4. Communicate constructively and avoid [demeaning](#demeaning-behavior) or
+   [insulting](#insulting-behavior) behavior or language.
+
+5. Seek, accept, and offer objective work criticism, and [acknowledge](#acknowledgement) properly
+   the contributions of others.
+
+6. Be honest about your own qualifications, and about any circumstances that might lead to conflicts
+   of interest.
+
+7. Respect the privacy of others and the confidentiality of data you access.
+
+8. With respect to cultural differences, be conservative in what you do and liberal in what you
+   accept from others, but not to the point of accepting disrespectful, unprofessional or unfair or
+   [unwelcome behavior](#unwelcome-behavior) or [advances](#unwelcome-sexual-advance).
+
+9. Promote the rules of this Code and take action (especially if you are in a
+   [leadership position](#leadership-position)) to bring the discussion back to a more civil level
+   whenever inappropriate behaviors are observed.
+
+10. Stay on topic: Make sure that you are posting to the correct channel and avoid off-topic
+    discussions. Remember when you update an issue or respond to an email you are potentially
+    sending to a large number of people.
+
+11. Step down considerately: Members of every project come and go, and the Hyperledger is no
+    different. When you leave or disengage from the project, in whole or in part, we ask that you do
+    so in a way that minimizes disruption to the project. This means you should tell people you are
+    leaving and take the proper steps to ensure that others can pick up where you left off.
+
+## Glossary
+
+### Demeaning Behavior
+
+is acting in a way that reduces another person's dignity, sense of self-worth or respect within the
+community.
+
+### Discrimination
+
+is the prejudicial treatment of an individual based on criteria such as: physical appearance, race,
+ethnic origin, genetic differences, national or social origin, name, religion, gender, sexual
+orientation, family or health situation, pregnancy, disability, age, education, wealth, domicile,
+political view, morals, employment, or union activity.
+
+### Insulting Behavior
+
+is treating another person with scorn or disrespect.
+
+### Acknowledgement
+
+is a record of the origin(s) and author(s) of a contribution.
+
+### Harassment
+
+is any conduct, verbal or physical, that has the intent or effect of interfering with an individual,
+or that creates an intimidating, hostile, or offensive environment.
+
+### Leadership Position
+
+includes group Chairs, project maintainers, staff members, and Board members.
+
+### Participant
+
+includes the following persons:
+
+- Developers
+- Member representatives
+- Staff members
+- Anyone from the Public partaking in the Hyperledger work environment (e.g. contribute code,
+  comment on our code or specs, email us, attend our conferences, functions, etc)
+
+### Respect
+
+is the genuine consideration you have for someone (if only because of their status as participant in
+Hyperledger, like yourself), and that you show by treating them in a polite and kind way.
+
+### Sexual Harassment
+
+includes visual displays of degrading sexual images, sexually suggestive conduct, offensive remarks
+of a sexual nature, requests for sexual favors, unwelcome physical contact, and sexual assault.
+
+### Unwelcome Behavior
+
+Hard to define? Some questions to ask yourself are:
+
+- how would I feel if I were in the position of the recipient?
+- would my spouse, parent, child, sibling or friend like to be treated this way?
+- would I like an account of my behavior published in the organization's newsletter?
+- could my behavior offend or hurt other members of the work group?
+- could someone misinterpret my behavior as intentionally harmful or harassing?
+- would I treat my boss or a person I admire at work like that ?
+- Summary: if you are unsure whether something might be welcome or unwelcome, don't do it.
+
+### Unwelcome Sexual Advance
+
+includes requests for sexual favors, and other verbal or physical conduct of a sexual nature, where:
+
+- submission to such conduct is made either explicitly or implicitly a term or condition of an
+  individual's employment,
+- submission to or rejection of such conduct by an individual is used as a basis for employment
+  decisions affecting the individual,
+- such conduct has the purpose or effect of unreasonably interfering with an individual's work
+  performance or creating an intimidating hostile or offensive working environment.
+
+### Workplace Bullying
+
+is a tendency of individuals or groups to use persistent aggressive or unreasonable behavior (e.g.
+verbal or written abuse, offensive conduct or any interference which undermines or impedes work)
+against a co-worker or any professional relations.
+
+### Work Environment
+
+is the set of all available means of collaboration, including, but not limited to messages to
+mailing lists, private correspondence, Web pages, chat channels, phone and video teleconferences,
+and any kind of face-to-face meetings or discussions.
+
+## Incident Procedure
+
+To report incidents or to appeal reports of incidents, send email to Mike Dolan
+(mdolan@linuxfoundation.org) or Angela Brown (angela@linuxfoundation.org). Please include any
+available relevant information, including links to any publicly accessible material relating to the
+matter. Every effort will be taken to ensure a safe and collegial environment in which to
+collaborate on matters relating to the Project. In order to protect the community, the Project
+reserves the right to take appropriate action, potentially including the removal of an individual
+from any and all participation in the project. The Project will work towards an equitable resolution
+in the event of a misunderstanding.
+
+## Credits
+
+This code is based on the
+[W3C’s Code of Ethics and Professional Conduct](https://www.w3.org/Consortium/cepc) with some
+additions from the [Cloud Foundry](https://www.cloudfoundry.org/)‘s Code of Conduct.

--- a/repo_structure/LICENSE
+++ b/repo_structure/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/repo_structure/README.md
+++ b/repo_structure/README.md
@@ -1,0 +1,103 @@
+# Common Repository Structure
+
+This tool provides a report about how a project lines up with the common repository structure
+
+## Common Structure
+
+This is a list of required and recommended files in each Hyperledger source repository. When there
+is a difference between the tool and this specification, the specification dominates.
+
+### Files with Specified Content
+
+Repositories MUST have these files with the specific content in the liked files. These files MUST be
+at the root of the repository
+
+- [`LICENSE`](LICENSE.md)
+- [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+- [`SECURITY.md`](SECURITY.md)
+
+(Note that current automation does not validate that the contents are identical).
+
+### Required Files
+
+Repositories MUST have these files. Named files MUST be at the root of the repository.
+
+- `README` or `README.md` \
+  A description of the project and contain information or links to information such as
+  - A reference to the apache license (required).
+  - The current and important past releases
+  - Documentation for developers and uses
+- `MAINTAINERS.md` \
+  A list of all current maintainers and contacts/identifiers of the maintainers, one of which must be
+  each maintainer's LFID. This file may be maintainer curated or mechanically produced.
+- `CONTRIBUTING.md` \
+  Directions on how to contribute code to the project, or a pointer to the Wiki page with that information.
+- `CHANGELOG.md` \
+  A human readable list of recent changes. Changes should at least include the current release. This
+  file may be maintainer curated or mechanically produced.
+- Testing code \
+  Code to test the code in the repository (such as unit tests), in a location appropriate for the language.
+- Continuous Integration / Continuous Delivery (CICD) configurations \
+  Configurations needed to run CICD on Hyperledger provided systems.
+
+### Recommended
+
+Repositories SHOULD have these files. These files SHOULD be at the root of the repository
+
+- `NOTICE`
+- Apache License Header information in each source code file \
+  This SHOULD include the snippet `SPDX-License-Identifier: Apache-2.0` as part of the header.
+- Build files consistent with the implementation language
+  - For JavaScript/Node.js a `package.json` file
+  - For Ruby a `Gemfile` file
+  - For Java one of a Maven `pom.xml`, an Apache Ant `build.xml`, or a Gralde `build.gradle` file
+  - For Python `setup.py` and `requirements.txt` files
+  - //TODO C, Go, and Rust build files
+
+### Prohibited
+
+Repositories MUST NOT have these files
+
+- Executable binaries and libraries \
+  This includes `.exe`, `.dll` files not otherwise part of a third party library.
+
+## Usage
+
+```
+repo_structure.sh [options]
+Reports on conformance to the Hyperledger Repository Structure.
+
+Options:
+    --fabric:   Include Fabric repositories
+    --sawtooth: Include Sawtooth repositories
+    --iroha:    Include Iroha repositories
+    --burrow:   Include Burrow repositories
+    --indy:     Include Indy repositories
+    --besu:     Include Besu repositories
+    --composer: Include Composer repositories
+    --cello:    Include Cello repositories
+    --explorer: Include Explorer repositories
+    --quilt:    Include Quilt repositories
+    --caliper:  Include Caliper repositories
+    --ursa:     Include Ursa repositories
+    --grid:     Include Grid repositories
+    --aries:    Include Aries repositories
+    --transact: Include Transact repositories
+    --avalon:   Include Avalon repositories
+    --projects: Include Project repositories
+    --labs:     Include Labs repositories
+    --other:    Include Other repositories
+    --gerrit:   Include Gerrit repositories
+    --github:   Include Github repositories
+    --all:      Include all repositories (default)
+    --since:    Includes commits more recent than this date (mm/dd/yyyy).
+                By default starts from the start of the repo.
+    --until:    Includes commits older than this date (mm/dd/yyyy).
+                By default ends at the end of the repo.
+    --output-dir <dir>: Where should output be placed. (Default: /tmp)
+    --help:     Shows this help message
+
+NOTE: If no options are specified, it is as if you had specified --all
+NOTE: Multiple repository options can be specified
+NOTE: --all will override all commands for individual projects
+```

--- a/repo_structure/README.md
+++ b/repo_structure/README.md
@@ -9,8 +9,8 @@ is a difference between the tool and this specification, the specification domin
 
 ### Files with Specified Content
 
-Repositories MUST have these files with the specific content in the liked files. These files MUST be
-at the root of the repository
+Repositories MUST have these files with the specific content in the linked files. These files MUST
+be at the root of the repository:
 
 - [`LICENSE`](LICENSE.md)
 - [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)

--- a/repo_structure/SECURITY.md
+++ b/repo_structure/SECURITY.md
@@ -1,0 +1,20 @@
+# Hyperledger Security Policy
+
+## Reporting a Security Bug
+
+If you think you have discovered a security issue in any of the Hyperledger projects, we'd love to
+hear from you. We will take all security bugs seriously and if confirmed upon investigation we will
+patch it within a reasonable amount of time and release a public security bulletin discussing the
+impact and credit the discoverer.
+
+There are two ways to report a security bug. The easiest is to email a description of the flaw and
+any related information (e.g. reproduction steps, version) to
+[security at hyperledger dot org](mailto:security@hyperledger.org).
+
+The other way is to file a confidential security bug in our
+[JIRA bug tracking system](https://jira.hyperledger.org). Be sure to set the “Security Level” to
+“Security issue”.
+
+The process by which the Hyperledger Security Team handles security bugs is documented further in
+our [Defect Response page](https://wiki.hyperledger.org/display/HYP/Defect+Response) on our
+[wiki](https://wiki.hyperledger.org).

--- a/repo_structure/repo_structure.sh
+++ b/repo_structure/repo_structure.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+#Default variables
+repositories=()
+filename="hyperledger-repository-structure"
+since=""
+until=""
+output_dir=/tmp
+INCLUDE_PROJECT_OPTIONS=1
+INCLUDE_DATE_OPTIONS=1
+short_description="Reports on conformance to the Hyperledger Repository Structure."
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+script_dir="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+. ${script_dir}/../common/command-line.sh
+
+today=`date -u +%Y-%m-%d-%H-%M-%S`
+outdir="${output_dir}"/${filename}-${today}
+outfile="${outdir}"/repo_structure.txt
+mkdir -p "${outdir}"/working
+
+srcdir=/tmp/${filename}-${today}
+mkdir -p ${srcdir}/source
+cd ${srcdir}/source
+
+for i in ${repositories[@]};
+do
+  echo "Processing $i..."
+  cd ${srcdir}/source
+  git clone --single-branch $i
+  repo=`basename -s .git $i`
+  cd ${repo}
+  echo >> ${outfile}
+  echo "Report for $i" >> ${outfile}
+
+  if [ -h "repolint.json" ]; then
+    echo custom repolint.json exists: >> ${outfile}
+    diff repolint.json ${script_dir}/repolint.json >> ${outfile}
+  fi
+  cp ${script_dir}/repolint.json .
+  npx repolinter >> ${outfile}
+  if [ ?$ ]; then
+    echo "FAILED" >> ${outfile}
+  fi
+done
+
+
+rm -fr ${srcdir}/source

--- a/repo_structure/repolint.json
+++ b/repo_structure/repolint.json
@@ -23,7 +23,10 @@
                 "circle.yml", 
                 ".circleci/config.yml", 
                 "ci/azure-pipelines.yml",
-                ".ci/azure-pipelines.yml"
+                ".ci/azure-pipelines.yml",
+                "Jenkinsfile",
+                "Jenkinsfile.ci",
+                "Jenkinsfile.cd"
               ]
             }
           ],

--- a/repo_structure/repolint.json
+++ b/repo_structure/repolint.json
@@ -1,0 +1,51 @@
+{
+    "axioms": {
+      "linguist":"language",
+      "licensee":"license",
+      "packagers":"packager"
+    },
+    "rules": {
+      "all": {
+        "license-file-exists:file-existence": ["error", {"files": ["LICENSE*", "COPYING*"]}],
+        "code-of-conduct-file-exists:file-existence": ["error", {"files": ["CODE_OF_CONDUCT.md"]}],
+        "security-file-exists:file-existence": ["error", {"files": ["SECURITY.md"]}],
+
+        "readme-file-exists:file-existence": ["error", {"files": ["README.md", "README"]}],
+        "readme-references-license:file-contents": ["error", {"files": ["README.md", "README"], "content": "license", "flags": "i"}],
+        "maintainers-file-exists:file-existence": ["error", {"files": ["MAINTAINERS.md"]}],
+        "contributing-file-exists:file-existence": ["error", {"files": ["CONTRIBUTING.md"]}],
+        "changelog-file-exists:file-existence": ["error", {"files": ["CHANGELOG.md"]}],
+        "test-directory-exists:directory-existence": ["error", {"directories": ["**/test*", "**/specs"], "nocase": true}],
+        "integrates-with-ci:file-existence": [
+            "error",
+            {
+              "files": [
+                "circle.yml", 
+                ".circleci/config.yml", 
+                "ci/azure-pipelines.yml"
+              ]
+            }
+          ],
+
+        "notice-file-exists:file-existence": ["warning", {"files": ["NOTICE*"]}],
+        "source-license-headers-exist:file-starts-with": ["warning", {"files": ["**/*.js", "!node_modules/**"], "lineCount": 5, "patterns": ["Copyright", "License"], "flags": "i"}],
+
+        "binaries-not-present:file-type-exclusion": ["error", {"type": ["**/*.exe", "**/*.dll", "!node_modules/**"]}]
+      },
+      "language=javascript": {
+        "package-metadata-exists:file-existence": ["warning", {"files": ["package.json"]}]
+      },
+      "language=ruby": {
+        "package-metadata-exists:file-existence": ["warning", {"files": ["Gemfile"]}]
+      },
+      "language=java": {
+        "package-metadata-exists:file-existence": ["warning", {"files": ["pom.xml", "build.xml", "build.gradle"]}]
+      },
+      "license=*": {
+        "license-detectable-by-licensee": ["warning"]
+      },
+      "language=python": {
+        "package-metadata-exists:file-existence": ["warning", {"files": ["setup.py", "requirements.txt"]}]
+      }
+    }
+  }

--- a/repo_structure/repolint.json
+++ b/repo_structure/repolint.json
@@ -22,7 +22,8 @@
               "files": [
                 "circle.yml", 
                 ".circleci/config.yml", 
-                "ci/azure-pipelines.yml"
+                "ci/azure-pipelines.yml",
+                ".ci/azure-pipelines.yml"
               ]
             }
           ],


### PR DESCRIPTION
This aims to make a spec based proposal that also addresses the
feedbak given to prior proposals and to the specifics of the repolinter
that were not objected to by anyone else.

I also updated the repolinter to make it run against all projects.  Some
hackery with copying the repolinter into the local cloned repo was
required as repolinter does not allow pointing to an external config.

Required content is not automatically checked, but is part of the spec.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>