### PR TITLE
Extend test directory check to Go test files

### DIFF
--- a/repo_structure/repolint.json
+++ b/repo_structure/repolint.json
@@ -15,7 +15,7 @@
         "maintainers-file-exists:file-existence": ["error", {"files": ["MAINTAINERS.md"]}],
         "contributing-file-exists:file-existence": ["error", {"files": ["CONTRIBUTING.md"]}],
         "changelog-file-exists:file-existence": ["error", {"files": ["CHANGELOG.md"]}],
-        "test-directory-exists:directory-existence": ["error", {"directories": ["**/test*", "**/specs"], "nocase": true}],
+        "test-directory-exists:directory-existence": ["error", {"directories": ["**/test*", "**/specs", "**/**_test.go"], "nocase": true}],
         "integrates-with-ci:file-existence": [
             "error",
             {


### PR DESCRIPTION
In a Go project test files are stored along with the code. This
patch extends the presence check on test directories to include
Go test files.

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>