### PR TITLE
Improve compliance to common repo structure

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+Code of Conduct Guidelines
+==========================
+
+Please review the Hyperledger [Code of
+Conduct](https://wiki.hyperledger.org/community/hyperledger-project-code-of-conduct)
+before participating. It is important that we keep things civil.
+
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+## Contributing
+
+We welcome contributions to this repository!
+
+Please commit your changes with proper sign-off. This means that your commit
+log message must contain a line that looks like the following one,
+with your actual name and email address:
+
+        Signed-off-by: John Doe <john.doe@example.com>
+
+Adding the `-s` flag to your `git commit` command will add that line
+automatically. You can also add it manually as part of your commit
+log message or add it afterwards with `git commit --amend -s`.
+
+## Code of Conduct Guidelines <a name="conduct"></a>
+
+See our [Code of Conduct Guidelines](./CODE_OF_CONDUCT.md).
+
+## Maintainers <a name="maintainers"></a>
+
+Should you have any questions or concerns, please reach out to one of the [Maintainers](./MAINTAINERS.md).
+
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,15 @@
+Maintainers
+===========
+
+This repo uses a non-author code review policy, requiring a single approval from a non-author maintainer.
+
+| Name | GitHub | Chat | email |
+|------|--------|------|-------|
+| Bas van Oostveen | [trbs](https://github.com/trbs)| trbs | <trbs@trbs.net>
+| Chris Ferris | [christo4ferris](https://github.com/christo4ferris) | cbf | <chris.ferris@gmail.com> |
+| David Boswell | [davidwboswell](https://github.com/davidwboswell) | davidboswell | <dboswell@linuxfoundation.org>
+| Richard Esplin | [esplinr](https://github.com/esplinr) | esplinr | <richard-oss@esplins.org>
+| Ry Jones | [ryjones](https://github.com/ryjones) | rjones | <ry@linux.com>
+| Tracy Kuhrt | [tkuhrt](https://github.com/tkuhrt) | tkuhrt | <tracy.a.kuhrt@accenture.com>
+
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
 # Hyperledger Community Management Tools
 Tools used to manage and evaluate the Hyperledger Community
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Hyperledger Security Policy
+
+## Reporting a Security Bug
+
+If you think you have discovered a security issue in any of the Hyperledger projects, we'd love to hear from you. We will take all security bugs seriously and if confirmed upon investigation we will patch it within a reasonable amount of time and release a public security bulletin discussing the impact and credit the discoverer.
+
+There are two ways to report a security bug. The easiest is to email a description of the flaw and any related information (e.g. reproduction steps, version) to [security at hyperledger dot org](mailto:security@hyperledger.org).
+
+The other way is to file a confidential security bug in our [JIRA bug tracking system](https://jira.hyperledger.org). Be sure to set the “Security Level” to “Security issue”.
+
+The process by which the Hyperledger Security Team handles security bugs is documented further in our [Defect Response page](https://wiki.hyperledger.org/display/HYP/Defect+Response) on our [wiki](https://wiki.hyperledger.org).
+


### PR DESCRIPTION
Added a bunch of missing files and a missing license.
With this change we're close to full compliance, not sure what to do about the tests and CI though:
```
Target directory: github.com/hyperledger/hyperledger-community-management-tools
Ruleset: repolint.json
✔ license-file-exists: found (LICENSE)
✔ code-of-conduct-file-exists: found (CODE_OF_CONDUCT.md)
✔ security-file-exists: found (SECURITY.md)
✔ readme-file-exists: found (README.md)
✔ readme-references-license: File README.md contains license
✔ maintainers-file-exists: found (MAINTAINERS.md)
✔ contributing-file-exists: found (CONTRIBUTING.md)
✔ changelog-file-exists: found (CHANGELOG.md)
✖ test-directory-exists: not found: (**/test*, **/specs)
✖ integrates-with-ci: not found: (circle.yml, .circleci/config.yml, ci/azure-pipelines.yml, .ci/azure-pipelines.yml, Jenkinsfile, Jenkinsfile.ci, Jenkinsfile.cd)
⚠ notice-file-exists: not found: (NOTICE*)
✔ binaries-not-present: Excluded file type doesn't exist (**/*.exe,**/*.dll,!node_modules/**)
⚠ package-metadata-exists: not found: (setup.py, requirements.txt)
✔ license-detectable-by-licensee: Licensee identified the license for project: Apache-2.0
```

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>