### PR TITLE
Move Testing code to warning, filter passing checks in CLI

### DIFF
--- a/repo_structure/README.md
+++ b/repo_structure/README.md
@@ -35,17 +35,15 @@ Repositories MUST have these files. Named files MUST be at the root of the repos
 - `CHANGELOG.md` \
   A human readable list of recent changes. Changes should at least include the current release. This
   file may be maintainer curated or mechanically produced.
-- Testing code \
-  Code to test the code in the repository (such as unit tests), in a location appropriate for the language.
 - Continuous Integration / Continuous Delivery (CICD) configurations \
   Configurations needed to run CICD on Hyperledger provided systems.
 
 ### Recommended
 
-Repositories SHOULD have these files. These files SHOULD be at the root of the repository
+Repositories SHOULD have these files. Named files SHOULD be at the root of the repository
 
 - `NOTICE`
-- Apache License Header information in each source code file \
+- Apache License Header information in each source code file. \
   This SHOULD include the snippet `SPDX-License-Identifier: Apache-2.0` as part of the header.
 - Build files consistent with the implementation language
   - For JavaScript/Node.js a `package.json` file
@@ -53,6 +51,9 @@ Repositories SHOULD have these files. These files SHOULD be at the root of the r
   - For Java one of a Maven `pom.xml`, an Apache Ant `build.xml`, or a Gralde `build.gradle` file
   - For Python `setup.py` and `requirements.txt` files
   - //TODO C, Go, and Rust build files
+- Testing code \
+  Code to test the code in the repository (such as unit tests), in a location appropriate for the language. \
+  Not all repositories can be tested (homebrew, docs), which is the only reason this is a SHOULD.
 
 ### Prohibited
 

--- a/repo_structure/repo_structure.sh
+++ b/repo_structure/repo_structure.sh
@@ -39,13 +39,13 @@ do
   echo >> ${outfile}
   echo "Report for $i" >> ${outfile}
 
-  if [ -h "repolint.json" ]; then
-    echo custom repolint.json exists: >> ${outfile}
-    diff repolint.json ${script_dir}/repolint.json >> ${outfile}
-  fi
   cp ${script_dir}/repolint.json .
-  npx repolinter >> ${outfile}
-  if [ $? -eq 0 ]; then
+  npx repolinter -r ${script_dir}/repolint.json > repoliter.tmpresult
+  set pass=$?
+  # Filter out passing and not-run tests
+  grep -v ✔ repoliter.tmpresult | grep -v ℹ >> ${outfile}
+  rm repoliter.tmpresult
+  if [ ${pass} -eq 0 ]; then
     echo "PASSED - $i" >> ${outfile}
   else
     echo "FAILED - $i" >> ${outfile}

--- a/repo_structure/repolint.json
+++ b/repo_structure/repolint.json
@@ -14,24 +14,24 @@
         "maintainers-file-exists:file-existence": ["error", {"files": ["MAINTAINERS.md", "MAINTAINERS.rst"]}],
         "contributing-file-exists:file-existence": ["error", {"files": ["CONTRIBUTING.md"]}],
         "changelog-file-exists:file-existence": ["error", {"files": ["CHANGELOG.md"]}],
-        "test-directory-exists:directory-existence": ["error", {"directories": ["**/test*", "**/specs", "**/**_test.go"], "nocase": true}],
         "integrates-with-ci:file-existence": [
-            "error",
-            {
-              "files": [
-                "circle.yml", 
-                ".circleci/config.yml", 
-                "ci/azure-pipelines.yml",
-                ".ci/azure-pipelines.yml",
-                "Jenkinsfile",
-                "Jenkinsfile.ci",
-                "Jenkinsfile.cd"
-              ]
-            }
-          ],
+          "error",
+          {
+            "files": [
+              "circle.yml",
+              ".circleci/config.yml",
+              "ci/azure-pipelines.yml",
+              ".ci/azure-pipelines.yml",
+              "Jenkinsfile",
+              "Jenkinsfile.ci",
+              "Jenkinsfile.cd"
+            ]
+          }
+        ],
 
         "notice-file-exists:file-existence": ["warning", {"files": ["NOTICE*"]}],
         "source-license-headers-exist:file-starts-with": ["warning", {"files": ["**/*.js", "!node_modules/**"], "lineCount": 5, "patterns": ["Copyright", "License"], "flags": "i"}],
+        "test-directory-exists:directory-existence": ["warning", {"directories": ["**/test*", "**/specs", "**/**_test.go"], "nocase": true}],
 
         "binaries-not-present:file-type-exclusion": ["error", {"type": ["**/*.exe", "**/*.dll", "!node_modules/**"]}]
       },
@@ -51,4 +51,4 @@
         "package-metadata-exists:file-existence": ["warning", {"files": ["setup.py", "requirements.txt"]}]
       }
     }
-  }
+}


### PR DESCRIPTION
* Add support for checking that testing files exist based on common file
  patterns.
* Fix the expression for checking for Maintainers file.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>