### PR TITLE
Fix MAINTAINERS file existence rule

### DIFF
--- a/repo_structure/repolint.json
+++ b/repo_structure/repolint.json
@@ -11,7 +11,7 @@
         "security-file-matches:file-contents": ["error", {"files": ["SECURITY.md"], "content": "https://wiki.hyperledger.org/display/SEC/Defect.Response", "fail-on-non-existent": true}],
         "readme-file-exists:file-existence": ["error", {"files": ["README.md", "README"]}],
         "readme-references-license:file-contents": ["error", {"files": ["README.md", "README"], "content": "license", "flags": "i"}],
-        "maintainers-file-exists:file-existence": ["error", {"files": ["MAINTAINERS.(md|rst)"]}],
+        "maintainers-file-exists:file-existence": ["error", {"files": ["MAINTAINERS.md", "MAINTAINERS.rst"]}],
         "contributing-file-exists:file-existence": ["error", {"files": ["CONTRIBUTING.md"]}],
         "changelog-file-exists:file-existence": ["error", {"files": ["CHANGELOG.md"]}],
         "test-directory-exists:directory-existence": ["error", {"directories": ["**/test*", "**/specs", "**/**_test.go"], "nocase": true}],


### PR DESCRIPTION
The regular expression used in maintainers-file-exists:file-existence
is not working. This changes the rule to using a list.

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>