### PR TITLE
github actions is an acceptable ci

### DIFF
--- a/repo_structure/repolint.json
+++ b/repo_structure/repolint.json
@@ -72,7 +72,8 @@
             ".ci/azure-pipelines.yml",
             "Jenkinsfile",
             "Jenkinsfile.ci",
-            "Jenkinsfile.cd"
+            "Jenkinsfile.cd",
+            ".github/workflows/*.yml"
           ]
         }
       ],


### PR DESCRIPTION
Both Burrow and Solang use github actions for CI.

Signed-off-by: Sean Young <sean@mess.org>