### PR TITLE
Improve compliance with common repo structure

### DIFF
--- a/voters/hashes.js
+++ b/voters/hashes.js
@@ -1,3 +1,9 @@
+/*
+ * Copyright contributors to Hyperledger.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 'use strict';
 
 class Hashes {

--- a/voters/index.html
+++ b/voters/index.html
@@ -1,3 +1,9 @@
+<!--
+  Copyright contributors to Hyperledger.
+ 
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 <!doctype html>
 <html lang="en">
 	<head>


### PR DESCRIPTION
In the "eat your own dog food" spirit, I ran repolinter which highlighted a couple of problems.
Fix link in SECURITY file and add missing copyright and license
notices.

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>