### PR TITLE
Expand header check to cover java and typescript files

### DIFF
--- a/repo_structure/repolint.json
+++ b/repo_structure/repolint.json
@@ -86,7 +86,18 @@
       "source-license-headers-exist:file-starts-with": [
         "warning",
         {
-          "files": ["**/*.js", "!**/node_modules/**", "**/*.go", "!**/vendor/**", "!**/*.pb.go", "!**/*.gen.go", "!**/third_party/**"],
+          "files": [
+            "**/*.js",
+            "**/*.ts",
+            "**/*.go",
+            "**/*.java",
+            "!**/node_modules/**",
+            "!**/vendor/**",
+            "!**/*.pb.go",
+            "!**/*.gen.go",
+            "!**/mocks/*.go",
+            "!**/third_party/**"
+          ],
           "lineCount": 7,
           "patterns": ["Copyright", "License"],
           "flags": "i"


### PR DESCRIPTION
Will now issue warnings for java and typescript files not containing a copyright or license

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>