### PR TITLE
ci: exclude third_party directory in repolint license checks

### DIFF
--- a/repo_structure/repolint.json
+++ b/repo_structure/repolint.json
@@ -86,7 +86,7 @@
       "source-license-headers-exist:file-starts-with": [
         "warning",
         {
-          "files": ["**/*.js", "!**/node_modules/**", "**/*.go", "!**/vendor/**", "!**/*.pb.go", "!**/*.gen.go"],
+          "files": ["**/*.js", "!**/node_modules/**", "**/*.go", "!**/vendor/**", "!**/*.pb.go", "!**/*.gen.go", "!**/third_party/**"],
           "lineCount": 7,
           "patterns": ["Copyright", "License"],
           "flags": "i"


### PR DESCRIPTION
Signed-off-by: Troy Ronda <troy.ronda@securekey.com>