### PR TITLE
Make CHANGELOG.md non-existence to warning

### DIFF
--- a/repo_structure/repolint.json
+++ b/repo_structure/repolint.json
@@ -56,12 +56,6 @@
           "files": ["CONTRIBUTING.md"]
         }
       ],
-      "changelog-file-exists:file-existence": [
-        "error",
-        {
-          "files": ["CHANGELOG.md"]
-        }
-      ],
       "integrates-with-ci:file-existence": [
         "error",
         {
@@ -75,6 +69,12 @@
             "Jenkinsfile.cd",
             ".github/workflows/*.yml"
           ]
+        }
+      ],
+      "changelog-file-exists:file-existence": [
+        "warning",
+        {
+          "files": ["CHANGELOG.md"]
         }
       ],
       "notice-file-exists:file-existence": [


### PR DESCRIPTION
A project having a clean commit history may feel it is redundant
to retain a separate CHANGELOG.md file. In addition to
CHANGELOG.md when a project is released, a new tag is created
and notes are added to it.

Signed-off-by: S m, Aruna <arun.s.m.cse@gmail.com>